### PR TITLE
fix: remove intersphinx breaking live build

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -154,7 +154,6 @@ custom_linkcheck_anchors_ignore_for_url = [
 # Add extensions
 custom_extensions = [
     'sphinx.ext.todo',
-    'sphinx.ext.intersphinx',
 ]
 
 # Add MyST extensions
@@ -191,6 +190,3 @@ custom_tags = []
 ############################################################
 
 ## Add any configuration that is not covered by the common conf.py file.
-
-intersphinx_mapping = {'ubuntu-pro': ('https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/', None),
-}

--- a/docs/how-to/enable-real-time-ubuntu.rst
+++ b/docs/how-to/enable-real-time-ubuntu.rst
@@ -17,9 +17,8 @@ use.
 .. important:: 
 
    Once you enable Real-time Ubuntu, it won't be possible to enable certain
-   other Pro services. The external documentation for Pro describes which
-   services are :external+ubuntu-pro:doc:`compatible with Real-time Ubuntu
-   <references/compatibility_matrix>`.
+   other Pro services. The external documentation for Pro Client describes which
+   services are `compatible with Real-time Ubuntu`_.
 
    Real-time Ubuntu is not compatible with Livepatch. If Livepatch is enabled
    when you install Real-time Ubuntu, Pro will offer to disable it before
@@ -100,3 +99,4 @@ After rebooting, you'll be running Real-time Ubuntu.
 .. _Real-time Ubuntu: https://ubuntu.com/real-time
 .. _contact the real-time team: https://ubuntu.com/kernel/real-time/contact-us
 .. _Ubuntu Pro: https://ubuntu.com/pro
+.. _compatible with Real-time Ubuntu: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/compatibility_matrix/


### PR DESCRIPTION
Removing the interspinx integration which has broken the live build feature:

```
$ make run
...
Running Sphinx v7.2.6
loading pickled environment... done
myst v2.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'deflist', 'linkify', 'substitution'}, disable_syntax=[], all_links_external=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
loading intersphinx inventory from https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/...
encountered some issues with some of the inventories, but they had working alternatives:
intersphinx inventory 'https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/' not readable due to ValueError: unknown or unsupported inventory version: ValueError('invalid inventory header: <!doctype html>')

Extension error (sphinx.ext.intersphinx):
Handler <function load_mappings at 0x70cdd7941620> for event 'builder-inited' threw an exception (exception: 'tuple' object has no attribute 'decode')
Sphinx exited with exit code: 2
The server will continue serving the build folder, but the contents being served are no longer in sync with the documentation sources. Please fix the cause of the error above or press Ctrl+C to stop the server.
...
```
