### PR TITLE
Add raspi and intel-iots variants

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -112,6 +112,7 @@ proc
 ps
 psr
 Permalink
+raspi
 RCU
 ReadMe
 realtime

--- a/docs/how-to/enable-real-time-ubuntu.rst
+++ b/docs/how-to/enable-real-time-ubuntu.rst
@@ -35,7 +35,7 @@ can access Pro services:
 Install and enable automatically
 --------------------------------
 
-Real-time Ubuntu kernel is installed using the APT package manager. If you wish to
+The Real-time Ubuntu kernel is installed using the APT package manager. If you wish to
 access the repository but not install the package immediately, skip to `Install
 and enable manually`_.
 
@@ -43,7 +43,7 @@ Otherwise, install Real-time Ubuntu and automatically select the right version
 for your OS and processor:
 
 .. note::
-   The different variants of the realtime kernel aren't available in very Ubuntu release.
+   The different variants of the realtime kernel aren't available in every Ubuntu release.
    Refer to :doc:`../reference/releases` for details.
 
 Choose Generic or a corresponding variant:

--- a/docs/how-to/enable-real-time-ubuntu.rst
+++ b/docs/how-to/enable-real-time-ubuntu.rst
@@ -61,7 +61,7 @@ Choose Generic or a corresponding variant:
          Using the Pro client to install it on these platforms will make the system unusable.
 
    .. group-tab:: Raspberry Pi
-      For Raspberry Pi 4 or 5:
+      For Raspberry Pi 4 and 5:
 
       .. code-block:: shell
 

--- a/docs/how-to/enable-real-time-ubuntu.rst
+++ b/docs/how-to/enable-real-time-ubuntu.rst
@@ -35,16 +35,44 @@ can access Pro services:
 Install and enable automatically
 --------------------------------
 
-Real-time Ubuntu is installed using the APT package manager. If you wish to
+Real-time Ubuntu kernel is installed using the APT package manager. If you wish to
 access the repository but not install the package immediately, skip to `Install
 and enable manually`_.
 
 Otherwise, install Real-time Ubuntu and automatically select the right version
 for your OS and processor:
 
-.. code-block:: shell
+.. note::
+   The different variants of the realtime kernel aren't available in very Ubuntu release.
+   Refer to :doc:`../reference/releases` for details.
 
-   sudo pro enable realtime-kernel
+Choose Generic or a corresponding variant:
+
+.. tabs::
+
+   .. group-tab:: Generic
+
+      .. code-block:: shell
+
+         sudo pro enable realtime-kernel
+      
+      .. caution::
+         The generic realtime kernel is not intended for Raspberry Pi.
+         Using the Pro client to install it on these platforms will make the system unusable.
+
+   .. group-tab:: Raspberry Pi
+      For Raspberry Pi 4 or 5:
+
+      .. code-block:: shell
+
+         sudo pro enable realtime-kernel --variant=raspi
+
+   .. group-tab:: Intel IOTG
+      For 12th Gen Intel® Core™ processors:
+
+      .. code-block:: shell
+
+         sudo pro enable realtime-kernel --variant=intel-iotg
 
 You'll need to acknowledge a warning, then you should see confirmation that the
 Real-time Ubuntu package is installed:
@@ -86,11 +114,14 @@ immediately, first use the ``--access-only`` flag:
    The ``--access-only`` flag was introduced in Pro Client version 27.11.
 
 Now that Real-time Ubuntu is accessible, you can install and enable it whenever
-you wish:
+you wish.
+
+For example, to install the generic realtime kernel (not suitable for Raspberry Pi):
 
 .. code-block:: shell
 
    sudo apt install ubuntu-realtime
+
 
 After rebooting, you'll be running Real-time Ubuntu.
 

--- a/docs/reference/releases.rst
+++ b/docs/reference/releases.rst
@@ -4,18 +4,21 @@ Real-time Ubuntu releases
 The following table shows the Ubuntu releases that support Real-time Ubuntu:
 
 .. list-table:: 
-   :widths: 25 25 50
+   :widths: 25 25 25 50
    :header-rows: 1
 
    * - Version
      - Code name
      - Real-time Kernel Version
-   * - Ubuntu 22.04 LTS
+     - Variants
+   * - Ubuntu 22.04
      - Jammy Jellyfish 
      - 5.15
-   * - Ubuntu 24.04 LTS
+     - generic, intel-iotg
+   * - Ubuntu 24.04
      - Noble Numbat
      - 6.8
+     - generic, raspi
 
 Refer to :doc:`../how-to/enable-real-time-ubuntu` to set up a supported Ubuntu version.
 


### PR DESCRIPTION
Future work: extend the manual installation method to cover the variants.

[Preview](https://canonical-real-time-ubuntu-documentation--34.com.readthedocs.build/en/34/)