### PR TITLE
Structural improvements to home and index pages

### DIFF
--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Explanation
 ===========
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -3,10 +3,25 @@ How-to guides
                                                                                                                     
 How-to guides cover key operations and processes for using Real-time Ubuntu.
 
+
+Get started with Real-time Ubuntu:
+
 .. toctree::
    :maxdepth: 1
 
    Enable Real-time Ubuntu <enable-real-time-ubuntu>
+
+Measure important metrics to determine system performance:
+
+.. toctree::
+   :maxdepth: 1
+
    Measure maximum latency <measure-maximum-latency>
+
+Tune performance for real-time processing:
+
+.. toctree::
+   :maxdepth: 1
+
    Configure CPUs for real-time processing <cpu-boot-configs>
    Tune IRQ affinity <tune-irq-affinity>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ In this documentation
       :doc:`boot parameters <reference/kernel-boot-parameters>` and
       :doc:`supported releases <reference/releases>`.
 
-   .. grid-item:: :doc:`Explanation <explanation/schedulers>`
+   .. grid-item:: Explanation
 
       **Conceptual information** about :doc:`explanation/schedulers`.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,8 +41,7 @@ In this documentation
    .. grid-item:: :doc:`How-to <how-to/index>`
 
       **Step-by-step guides** covering key operations and common tasks,
-      including :doc:`installation <how-to/enable-real-time-ubuntu>` and
-      :doc:`configuration <how-to/cpu-boot-configs>`.
+      including installation and configuration.
 
 .. grid:: 1 1 2 2
    :reverse:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,22 +36,27 @@ In this documentation
 
    .. grid-item:: :doc:`Tutorial <tutorial/index>`
 
-      **Start here**: a hands-on introduction to Real-time Ubuntu for new users
+      **Start here**: a hands-on introduction to Real-time Ubuntu for new users.
 
    .. grid-item:: :doc:`How-to <how-to/index>`
 
-      **Step-by-step guides** covering key operations and common tasks
+      **Step-by-step guides** covering key operations and common tasks,
+      including :doc:`installation <how-to/enable-real-time-ubuntu>` and
+      :doc:`configuration <how-to/cpu-boot-configs>`.
 
 .. grid:: 1 1 2 2
    :reverse:
 
    .. grid-item:: :doc:`Reference <reference/index>`
 
-      **Technical information** --- specifications, APIs, architecture
+      **Technical information** about
+      :doc:`metric tools <reference/real-time-metrics-tools>`,
+      :doc:`boot parameters <reference/kernel-boot-parameters>` and
+      :doc:`supported releases <reference/releases>`.
 
-   .. grid-item:: :doc:`Explanation <explanation/index>`
+   .. grid-item:: :doc:`Explanation <explanation/schedulers>`
 
-      **Discussion and clarification** of key topics
+      **Conceptual information** about :doc:`explanation/schedulers`.
 
 .. toctree::
    :maxdepth: 1
@@ -60,7 +65,7 @@ In this documentation
    tutorial/index
    how-to/index
    reference/index
-   explanation/index
+   Explanation: Linux kernel schedules <explanation/schedulers>
 
 ---------
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,13 +1,10 @@
 Reference
 =========
 
-Reference material succinctly describes commands, options, API elements and
-other features of Real-time Ubuntu.
-
 .. toctree::
    :maxdepth: 1
 
-   releases
    real-time-metrics-tools
    kernel-boot-parameters
+   releases
 


### PR DESCRIPTION
This update is based on an internal review of the current RTU docs.

The changes addressed in this update:

1. Home page / landing page Diataxis map description is more specific to RTU docs to provide better context on what to expect.
2. Provide context about the categories of how-to guides that are available to help users with RTU.
3. Remove "intro" for the Reference section; not necessary.
4. Move "Supported releases" to the bottom since that is about supported Ubuntu versions and not so much about RTU features.
5. Removed "section" for Explanation because the current docs only has a single Explanation document.

I did not update the tutorial as I think it would be better to discuss it first since grouping the content would require a significant amount of restructuring.