### PR TITLE
docs: fixed spelling and linkcheck errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The guidelines below will help keep your contributions effective and meaningful.
 
 When contributing, you must abide by the [Ubuntu Code of Conduct].
 
-## Licence and copyright
+## License and copyright
 
 Unless explicitly stated in the license headers of source files, all
 contributions to Real-time Ubuntu documentation are licensed under the Creative
@@ -18,7 +18,7 @@ To view a copy of this license, visit
 http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative
 Commons, 171 Second Street, Suite 300, San Francisco, California, 94105, USA.
 
-All contributors must sign the [Canonical contributor licence agreement],
+All contributors must sign the [Canonical contributor license agreement],
 which grants Canonical permission to use the contributions. The author of a
 change remains the copyright owner of their code (no copyright assignment
 occurs).
@@ -144,7 +144,7 @@ git commit -m "docs(ref/kernel-boot): Add example for nohz parameter" -s
 <!-- LINKS -->
 
 [Ubuntu Code of Conduct]: https://ubuntu.com/community/ethos/code-of-conduct
-[Canonical contributor licence agreement]: https://ubuntu.com/legal/contributors
+[Canonical contributor license agreement]: https://ubuntu.com/legal/contributors
 [Real-time Ubuntu releases]: https://documentation.ubuntu.com/real-time/en/latest/reference/releases/
 [Canonical's Sphinx starter pack]: https://github.com/canonical/sphinx-docs-starter-pack
 [Read the Docs]: https://about.readthedocs.com/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,7 +197,10 @@ linkcheck_ignore = [
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
 
-linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/.*",
+    r"https://snapcraft\.io/docs/.*"
+    ]
 
 
 ########################
@@ -326,6 +329,6 @@ latex_elements = ast.literal_eval(latex_config.replace("$PROJECT", project))
 
 myst_substitutions = {
   "U_COC": "[Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct)",
-  "C_CLA": "[Canonical contributor licence agreement](https://ubuntu.com/legal/contributors)",
+  "C_CLA": "[Canonical contributor license agreement](https://ubuntu.com/legal/contributors)",
   "PROJNAME_FULL": "Real-time Ubuntu documentation",
 }


### PR DESCRIPTION
- Updated all occurrences of 'licence' to 'license'
- Added snapcraft.io docs to linkcheck_anchors_ignore_for_url to ensure docs-checks can still pass without impacting the user experience