### PR TITLE
fix: use code format for --devmode on tutorial

### DIFF
--- a/docs/tutorial/7-snapping.md
+++ b/docs/tutorial/7-snapping.md
@@ -267,7 +267,7 @@ rt-app 0.1 installed
 
 ```{note}
 Since the snap is being installed from a local snap bundle, you would typically install it in [Dangerous Mode][snap_install_modes] to bypass signature verification.
-However, because the snap uses `confinement: devmode`, it must be installed using Developer Mode (\-\-devmode).
+However, because the snap uses `confinement: devmode`, it must be installed using Developer Mode (`--devmode`).
 This mode not only skips signature checks, but also allows installing snaps that use [Developer Mode confinement][snap_confinement].
 ```
 


### PR DESCRIPTION
When it comes to usage of double dash for showing command line options "--" seem that the sphinx doesn't render it properly (as separated dashes) neither if you try to scape them.

Using backticks to render as code does the job:

![image](https://github.com/user-attachments/assets/b0138885-9314-445f-a720-2b7c574c5b81)
