### PR TITLE
Remove doc tutorial prefix

### DIFF
--- a/docs/tutorial/first-rt-app/index.rst
+++ b/docs/tutorial/first-rt-app/index.rst
@@ -1,4 +1,4 @@
-Tutorial: Your first Real-time Ubuntu application
+Your first Real-time Ubuntu application
 =================================================
 
 In this tutorial we will build a simple C program for a real-time workload.


### PR DESCRIPTION
The original tutorial has the prefix "Tutorial: ", which shows up in the menus too. This is not necessary as there is now a higher level menu called "Tutorial".

![image](https://github.com/user-attachments/assets/4a8cd6e6-cf07-498a-83ef-5384804d363e)
