### PR TITLE
Run test app natively in TCC tutorial 

### DIFF
--- a/docs/tutorial/intel-tcc/code/docker-compose/docker-compose.yml
+++ b/docs/tutorial/intel-tcc/code/docker-compose/docker-compose.yml
@@ -27,7 +27,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ###################################################################################
-version: "3.3"
 
 services:
   mosquitto:

--- a/docs/tutorial/intel-tcc/code/rt_linux_tutorial.c
+++ b/docs/tutorial/intel-tcc/code/rt_linux_tutorial.c
@@ -65,8 +65,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #define STATS_THREAD_CORE 1
 
 // MQTT Settings
-//#define ADDRESS     "tcp://localhost:1883" // use localhost if app does not run in container
-#define ADDRESS     "tcp://mosquitto:1883"
+#define ADDRESS     "tcp://localhost:1883" // use localhost if app runs natively
+//#define ADDRESS     "tcp://mosquitto:1883" // use container hostname if using docker
 #define CLIENTID    "TCC_ClientPub"
 #define TOPIC       "sensor/data"
 #define QOS         1

--- a/docs/tutorial/intel-tcc/intel-cat.md
+++ b/docs/tutorial/intel-tcc/intel-cat.md
@@ -23,7 +23,7 @@ In both scenarios, a memory-centric workload on the best-effort cores is simulat
 1. Start the real-time application if it is not already running, and output the statistics to the Grafana dashboard.
  
    ```bash
-   ./rt_linux_tutorial -i 1000 -s 1
+   sudo ./rt_linux_tutorial -i 1000 -s 1
    ```
  
 2. In a second terminal start stress-ng with a memory-centric stressor.

--- a/docs/tutorial/intel-tcc/preparation.md
+++ b/docs/tutorial/intel-tcc/preparation.md
@@ -59,17 +59,17 @@ sudo addgroup --system docker
 sudo adduser $USER docker
 ```
 
+Apply the group permissions to your current session, or log out and log back in.
+
+```
+newgrp docker
+```
+
 Restart the docker service for it to be aware of the new group.
 
 ```
 sudo snap disable docker
 sudo snap enable docker
-```
-
-Apply the group permissions to your current session, or log out and log back in.
-
-```
-newgrp docker
 ```
 
 ### Start the services
@@ -88,6 +88,8 @@ Make sure it says "Up" in the status column.
 ```
 docker compose ps
 ```
+
+<!-- Grafana can take a minute or two to process all the database migrations when it starts up for the first time -->
 
 If everything is running, you can connect to Grafana by following these steps:
 1. Open your preferred web browser.

--- a/docs/tutorial/intel-tcc/preparation.md
+++ b/docs/tutorial/intel-tcc/preparation.md
@@ -94,7 +94,7 @@ It may take a few minutes until Grafana starts up for the first time.
 If the web interface is not immediately available, wait a minute and try again.
 ```
 
-When everything is ready, you can access Grafana's web interface by following these steps:
+When everything is ready, you can access {spellexception}`Grafana's` web interface by following these steps:
 1. Open your preferred web browser.
 1. Enter the following URL in the address bar: [http://localhost:3000/](http://localhost:3000/)
    - If you are running Docker on a remote server, replace `localhost` with the server's IP address or domain name.

--- a/docs/tutorial/intel-tcc/preparation.md
+++ b/docs/tutorial/intel-tcc/preparation.md
@@ -89,7 +89,10 @@ Make sure it says "Up" in the status column.
 docker compose ps
 ```
 
-<!-- Grafana can take a minute or two to process all the database migrations when it starts up for the first time -->
+```{note}
+After the Grafana container is up, it still takes a bit of time to create its internal database and completely start up.
+If the web interface is not immediately available, wait a minute and try again.
+```
 
 If everything is running, you can connect to Grafana by following these steps:
 1. Open your preferred web browser.

--- a/docs/tutorial/intel-tcc/preparation.md
+++ b/docs/tutorial/intel-tcc/preparation.md
@@ -59,13 +59,13 @@ sudo addgroup --system docker
 sudo adduser $USER docker
 ```
 
-Apply the group permissions to your current session, or log out and log back in.
+Apply the group changes to your current session:
 
 ```
 newgrp docker
 ```
 
-Restart the docker service for it to be aware of the new group.
+Restart the docker service for it to be aware of the new group:
 
 ```
 sudo snap disable docker
@@ -90,11 +90,11 @@ docker compose ps
 ```
 
 ```{note}
-After the Grafana container is up, it still takes a bit of time to create its internal database and completely start up.
+It may take a few minutes until Grafana starts up for the first time.
 If the web interface is not immediately available, wait a minute and try again.
 ```
 
-If everything is running, you can connect to Grafana by following these steps:
+When everything is ready, you can access Grafana's web interface by following these steps:
 1. Open your preferred web browser.
 1. Enter the following URL in the address bar: [http://localhost:3000/](http://localhost:3000/)
    - If you are running Docker on a remote server, replace `localhost` with the server's IP address or domain name.

--- a/docs/tutorial/intel-tcc/speed-shift.md
+++ b/docs/tutorial/intel-tcc/speed-shift.md
@@ -29,7 +29,7 @@ More information about HWP and the MSR can be found in the [Intel® 64 and IA-32
 
 1. Start the real-time application if it is not already running, and output the statistics to the Grafana dashboard.
    ```bash
-   ./rt_linux_tutorial -i 1000 -s 1
+   sudo ./rt_linux_tutorial -i 1000 -s 1
    ```
 
    Monitor the statistics and in a second terminal start *stress-ng* with a memory-centric stressor.

--- a/docs/tutorial/intel-tcc/tcc-mode.md
+++ b/docs/tutorial/intel-tcc/tcc-mode.md
@@ -32,12 +32,12 @@ The block diagram below illustrates the setup used for the *Intel® TCC Mode* an
  
 ## Run experiment
 
-1. Boot the system with the default BIOS options, and start the `intel_tcc_tutorial_image` Docker container.
-   Inside it start the real-time application with a cycle time of 1ms, and output the statistics to the Grafana dashboard.
+1. Boot the system with the default BIOS options.
+   Start the real-time application with a cycle time of 1ms, and output the statistics to the Grafana dashboard.
    Let the test application run for some seconds and monitor the statistics.
 
    ```sh
-   ./rt_linux_tutorial -i 1000 -s 1
+   sudo ./rt_linux_tutorial -i 1000 -s 1
    ```
 
 2. Reboot the system and enable *Intel® TCC Mode* in the BIOS.

--- a/docs/tutorial/intel-tcc/test-application.md
+++ b/docs/tutorial/intel-tcc/test-application.md
@@ -26,7 +26,7 @@ sudo apt install make gcc libpaho-mqtt-dev libcjson-dev
 ```
 
 The source code for the test application is available in the code archive you downloaded earlier.
-Make any required changes to the C program code, like modifying the `WORKLOAD_BUFFER_SIZE`.
+Make any required changes to the C program code, such as modifying the `WORKLOAD_BUFFER_SIZE`.
 Then compile the application using the provided Makefile:
 
 ```{terminal}
@@ -39,7 +39,7 @@ gcc -Wall -Wextra -O2 -I/usr/local/include -c pointer_chasing.c
 gcc -Wall -Wextra -O2 -I/usr/local/include -o rt_linux_tutorial rt_linux_tutorial.o pointer_chasing.o -L/usr/local/lib -lpaho-mqtt3c -lcjson
 ```
 
-The resulting binary can be run with the `-h` flag to see a summary of options:
+Run the resulting binary with the `-h` flag to see a summary of options:
 
 ```{terminal}
 :user: ubuntu

--- a/docs/tutorial/intel-tcc/test-application.md
+++ b/docs/tutorial/intel-tcc/test-application.md
@@ -17,38 +17,34 @@ The pointer chasing buffer size should exceed the L2 cache size of your processo
 You can change the buffer size in `rt_linux_tutorial.c` by editing the `WORKLOAD_BUFFER_SIZE` definition.
 ```
 
-## Build the docker image for the test application
+## Build the test application
+
+To build the application, you need Makefile support, the GCC compiler, the Paho MQTT library, and the cJSON library:
+
+```bash
+sudo apt install make gcc libpaho-mqtt-dev libcjson-dev
+```
 
 The source code for the test application is available in the code archive you downloaded earlier.
-
-First make any required changes to the C program code, like modifying the `WORKLOAD_BUFFER_SIZE`.
-Then build the Docker image by running the following command in the directory containing {file}`Dockerfile`:
-
-```bash
-cd tutorial-intel-tcc-code
-docker build -t intel_tcc_tutorial_image .
-```
-
-To verify that the image was built successfully, list all Docker images:
-
-```bash
-docker images
-```
-
-You should see `intel_tcc_tutorial_image` listed among the images.
-
-Run a new interactive container using this image:
-
-```bash
-docker run -it --privileged --rm --network docker-compose_stats intel_tcc_tutorial_image
-```
-
-Inside the container the `rt_linux_tutorial` application can be started:
+Make any required changes to the C program code, like modifying the `WORKLOAD_BUFFER_SIZE`.
+Then compile the application using the provided Makefile:
 
 ```{terminal}
-:user: root
-:host: container
-:dir: ~
+:user: ubuntu
+:host: ubuntu
+:dir: ~/tutorial-intel-tcc-code
+:input: make
+gcc -Wall -Wextra -O2 -I/usr/local/include   -c -o rt_linux_tutorial.o rt_linux_tutorial.c
+gcc -Wall -Wextra -O2 -I/usr/local/include -c pointer_chasing.c
+gcc -Wall -Wextra -O2 -I/usr/local/include -o rt_linux_tutorial rt_linux_tutorial.o pointer_chasing.o -L/usr/local/lib -lpaho-mqtt3c -lcjson
+```
+
+The resulting binary can be run with the `-h` flag to see a summary of options:
+
+```{terminal}
+:user: ubuntu
+:host: ubuntu
+:dir: ~/tutorial-intel-tcc-code
 :input: ./rt_linux_tutorial -h
 Usage: rt_linux_tutorial [OPTIONS]
 Options:
@@ -60,7 +56,7 @@ Options:
 Run it with MQTT support.
 
 ```bash
-./rt_linux_tutorial -i 1000 -s 1
+sudo ./rt_linux_tutorial -i 1000 -s 1
 ```
 
 Data should start appearing on the Grafana dashboard.


### PR DESCRIPTION
This change simplifies the steps to run the example RT application, by not using Docker. The application has very little dependencies, which can all be installed from the deb archive.