### PR TITLE
docs(explanation/schedulers) Fix spelling

### DIFF
--- a/docs/explanation/schedulers.rst
+++ b/docs/explanation/schedulers.rst
@@ -160,7 +160,7 @@ scheduled to run in the following order:
    | Pe           | 210          | 130            |            
    +--------------+--------------+----------------+
 
-Note that in the picture bellow, the tasks index represents the remaining time in
+Note that in the picture below, the tasks index represents the remaining time in
 milliseconds for each task to finish its execution.
 
 .. image:: rr_scheduler.svg


### PR DESCRIPTION
Closes #140 (Verbage error in Linux Kernel Schedulers page)