### PR TITLE
docs(ref/kernel-config-options) Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ deterministic response times.
 
 ## Project and community
 
-The Real-time Ubuntu project welcomes community contributions, suggestions,
+The Real-time Ubuntu documentation project welcomes community contributions, suggestions,
 fixes and constructive feedback. If you wish to contribute to Real-time Ubuntu,
 please follow [the guide][contribute].
 

--- a/docs/reference/kernel-config-options.rst
+++ b/docs/reference/kernel-config-options.rst
@@ -5,7 +5,7 @@ Real-time Ubuntu kernel configuration options are crucial for achieving low-late
 This document outlines various kernel config options, that Real Time Ubuntu uses on it's real-time kernel.
 These options enable and optimize preemption, manage IRQs, and control block I/O latency, among other features, that make Ubuntu real-time capable.
 
-All the configurations bellow are kernel config options, that begin with **CONFIG_**, but this prefix is omitted in the following sections for brevity.
+All the configurations below are kernel config options, that begin with **CONFIG_**, but this prefix is omitted in the following sections for brevity.
 
 
 >>>>


### PR DESCRIPTION
Another issue related to #140.

The word **bellow** was used rather than **below** to describe something underneath.

Also addressed concerns posed by myself for #46. Updated the README in accordance to my comment.