### PR TITLE
docs: add intersphinx mapping for ubu pro client

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,6 +266,7 @@ extensions = [
     "myst_parser",
     'sphinx.ext.todo',
     'sphinx_sitemap',
+    "sphinx.ext.intersphinx",
 ]
 
 # Excludes files or directories from processing
@@ -343,3 +344,8 @@ if 'READTHEDOCS_VERSION' in os.environ:
     sitemap_url_scheme = '{version}{link}'
 else:
     sitemap_url_scheme = '{link}'
+
+# Intersphinx mapping for other Canonical Sphinx projects
+intersphinx_mapping = {
+    "ubu-pro-client": ("https://documentation.ubuntu.com/pro-client/en/latest/", None),
+}

--- a/docs/how-to/enable-real-time-ubuntu.md
+++ b/docs/how-to/enable-real-time-ubuntu.md
@@ -2,7 +2,7 @@
 
 ## Ubuntu Classic
 
-To enable Real-time Ubuntu on a supported LTS release, follow the instructions in the [Ubuntu Pro Client - How to enable Real-time Ubuntu](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/enable_realtime_kernel/) guide.
+To enable Real-time Ubuntu on a supported LTS release, follow the instructions in the {doc}`Ubuntu Pro Client - How to enable Real-time Ubuntu <ubu-pro-client:howtoguides/enable_realtime_kernel>` guide.
 
 If you are running an interim release, Real-time Ubuntu can instead be installed from the universe apt repository:
 

--- a/docs/how-to/modify-kernel-boot-parameters.rst
+++ b/docs/how-to/modify-kernel-boot-parameters.rst
@@ -205,7 +205,7 @@ Read more on :doc:`../how-to/uc-image-creation`.
 .. LINKS
 .. _/boot/firmware/cmdline.txt: https://www.raspberrypi.com/documentation/computers/configuration.html#kernel-command-line-cmdline-txt
 .. _Ubuntu Core: https://ubuntu.com/core
-.. _update-grub: https://manpages.ubuntu.com/manpages/questing/en/man8/update-grub.8.html
+.. _update-grub: https://manpages.ubuntu.com/manpages/noble/en/man8/update-grub.8.html
 .. _snap set: https://ubuntu.com/core/docs/modify-kernel-options
 .. _system.kernel.cmdline-append: https://snapcraft.io/docs/system-options#heading--kernel-cmdline-append
 .. _system.kernel.dangerous-cmdline-append: https://snapcraft.io/docs/system-options#heading--kernel-dangerous-cmdline-append

--- a/docs/how-to/modify-kernel-boot-parameters.rst
+++ b/docs/how-to/modify-kernel-boot-parameters.rst
@@ -205,7 +205,7 @@ Read more on :doc:`../how-to/uc-image-creation`.
 .. LINKS
 .. _/boot/firmware/cmdline.txt: https://www.raspberrypi.com/documentation/computers/configuration.html#kernel-command-line-cmdline-txt
 .. _Ubuntu Core: https://ubuntu.com/core
-.. _update-grub: https://manpages.ubuntu.com/manpages/xenial/man8/update-grub.8.html
+.. _update-grub: https://manpages.ubuntu.com/manpages/questing/en/man8/update-grub.8.html
 .. _snap set: https://ubuntu.com/core/docs/modify-kernel-options
 .. _system.kernel.cmdline-append: https://snapcraft.io/docs/system-options#heading--kernel-cmdline-append
 .. _system.kernel.dangerous-cmdline-append: https://snapcraft.io/docs/system-options#heading--kernel-dangerous-cmdline-append

--- a/docs/tutorial/intel-tcc/preparation.md
+++ b/docs/tutorial/intel-tcc/preparation.md
@@ -20,7 +20,7 @@ It explains which software components are required and how to set it up.
    For the real-time kernel to be used, a reboot is required.
    We will reboot when we [add kernel command-line parameters](kernel-parameters).
 
-   Refer to [How to enable Real-time Ubuntu](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/enable_realtime_kernel/) for more details.
+   Refer to {doc}`Ubuntu Pro Client - How to enable Real-time Ubuntu <ubu-pro-client:howtoguides/enable_realtime_kernel>` for more details.
 
 ## Other required software
 


### PR DESCRIPTION
Use intersphinx mapping when referencing Ubuntu Pro Client docs to surface link issues with `make run` or `make html`.