### PR TITLE
Plucky to resolute

### DIFF
--- a/docs/how-to/create-rt-ubuntu-vm-using-kvm.md
+++ b/docs/how-to/create-rt-ubuntu-vm-using-kvm.md
@@ -133,7 +133,7 @@ Verify the kernel boot command line:
 
 cat /proc/cmdline
 
-BOOT_IMAGE=/vmlinuz-6.14.0-28-generic root=/dev/mapper/ubuntu--vg-ubuntu--lv ro quiet splash clocksource=tsc tsc=reliable nmi_watchdog=0 nosoftlockup kthread_cpus=0-7 isolcpus=domain,managed_irq,8-15 rcu_nocb_poll rcu_nocbs=8-15 nohz=on nohz_full=8-15 irqaffinity=0-7 idle=poll
+BOOT_IMAGE=/vmlinuz-6.17.0-16-generic root=/dev/mapper/ubuntu--vg-ubuntu--lv ro quiet splash clocksource=tsc tsc=reliable nmi_watchdog=0 nosoftlockup kthread_cpus=0-7 isolcpus=domain,managed_irq,8-15 rcu_nocb_poll rcu_nocbs=8-15 nohz=on nohz_full=8-15 irqaffinity=0-7 idle=poll
 ```
 
 Check which CPUs the kernel considers isolated (`8-15`):

--- a/docs/how-to/enable-real-time-ubuntu.md
+++ b/docs/how-to/enable-real-time-ubuntu.md
@@ -29,6 +29,9 @@ sudo apt install ubuntu-realtime
 
 ````{group-tab} Ubuntu 26.04 LTS (Resolute Raccoon)
 
+```{note}
+This will be available in upcoming Ubuntu 26.04 LTS (Resolute Raccoon) release.
+```
 Real-time Ubuntu can instead be installed from the universe apt repository:
 
 ```shell

--- a/docs/how-to/enable-real-time-ubuntu.md
+++ b/docs/how-to/enable-real-time-ubuntu.md
@@ -11,15 +11,34 @@ Follow the instructions that match your edition to ensure a correct installation
 
 ## Ubuntu Server / Desktop
 
-To enable Real-time Ubuntu on a supported LTS release, follow the instructions in the {doc}`Ubuntu Pro Client - How to enable Real-time Ubuntu <ubu-pro-client:howtoguides/enable_realtime_kernel>` guide.
+`````{tabs}
 
-If you are running an interim release, Real-time Ubuntu can instead be installed from the universe apt repository:
+````{group-tab} Ubuntu 24.04 LTS (Noble Numbat) or earlier
+Follow the instructions in the {doc}`Ubuntu Pro Client - How to enable Real-time Ubuntu <ubu-pro-client:howtoguides/enable_realtime_kernel>` guide.
+````
+
+````{group-tab} Ubuntu 25.10 (Questing Quokka)
+Real-time Ubuntu can instead be installed from the universe apt repository:
 
 ```shell
 sudo add-apt-repository universe
 sudo apt update
 sudo apt install ubuntu-realtime
 ```
+````
+
+````{group-tab} Ubuntu 26.04 LTS (Resolute Raccoon)
+
+Real-time Ubuntu can instead be installed from the universe apt repository:
+
+```shell
+sudo add-apt-repository universe
+sudo apt update
+sudo apt install ubuntu-realtime
+```
+````
+
+`````
 
 Refer to {doc}`/reference/releases` and [Ubuntu release](https://ubuntu.com/about/release-cycle) documentation for more information about Ubuntu releases and which support real-time.
 

--- a/docs/how-to/switch-from-realtime-to-generic-kernel.md
+++ b/docs/how-to/switch-from-realtime-to-generic-kernel.md
@@ -36,7 +36,7 @@ apt list linux-generic* --installed
 
 linux-generic-6.11/noble-updates,noble-security,now 6.11.0-29.29~24.04.1 amd64 [installed]
 linux-generic-6.14/noble-updates,noble-security,now 6.14.0-24.24~24.04.3 amd64 [installed]
-linux-generic-hwe-24.04/noble-updates,noble-security,now 6.14.0-24.24~24.04.3 amd64 [installed]
+linux-generic-hwe-24.04/noble-updates,noble-security,now 6.17.0-14.14~24.04.1 amd64 [installed]
 ```
 
 ````

--- a/docs/how-to/uc-install-real-time-kernel.md
+++ b/docs/how-to/uc-install-real-time-kernel.md
@@ -35,16 +35,16 @@ Filter results with `grep`. For example, here are the stable real-time kernels c
 
 snap info pc-kernel | grep 24-rt | grep stable
 
-  24-rt-hwe-edge/stable:    6.17.0-1004.5~24.04.2       2025-12-16 (3092) 385MB -
-  24-rt-hwe/stable:         6.14.0-1016.16~24.04.1      2025-11-20 (2968) 377MB -
-  24-rt/stable:             6.8.1-1038.39               2025-11-20 (2948) 360MB -
+  24-rt-hwe-edge/stable:    6.17.0-1006.7~24.04.1       2026-02-16 (3157) 392MB -
+  24-rt-hwe/stable:         6.17.0-1006.7~24.04.1       2026-02-16 (3157) 392MB -
+  24-rt/stable:             6.8.1-1041.42               2026-02-24 (3138) 362MB -
 ```
 
 Each row shows a snap channel, version, date, revision, and size. In reverse order:
 
-* `24-rt/stable` channel contains the real-time kernel for Ubuntu 24.04 LTS. The release is stable. The snap version `6.8.1-1023.24` indicates that the kernel version is 6.8.1.
-* `24-rt-hwe/stable` contains the real-time [Hardware Enablement (HWE)][HWE] kernel for Ubuntu 24.04 LTS. The kernel version is 6.14.0.
-* `24-rt-hwe-edge/stable` provides the most recent kernel version. The `-edge` suffix in the track indicates that this is an [edge kernel][edge-kernel] published for early access to the 6.17 kernel.
+* `24-rt/stable` channel contains the real-time kernel for Ubuntu 24.04 LTS. The release is stable. The snap version `6.8.1-1041.42` indicates that the kernel version is 6.8.1.
+* `24-rt-hwe/stable` contains the real-time [Hardware Enablement (HWE)][HWE] kernel for Ubuntu 24.04 LTS. The kernel version is 6.17.
+% * `24-rt-hwe-edge/stable` provides the most recent kernel version. The `-edge` suffix in the track indicates that this is an [edge kernel][edge-kernel] published for early access to the 6.17 kernel.
 
 ```{seealso}
 Read more about the [Ubuntu kernel lifecycle][kernel-lifecycle] and [HWE kernels][hwe-kernels].

--- a/docs/reference/releases.rst
+++ b/docs/reference/releases.rst
@@ -23,14 +23,14 @@ Ubuntu Server / Desktop
      - Noble Numbat
      - 6.8
      - generic, raspi
-   * - Ubuntu 25.04
-     - Plucky Puffin
-     - 6.14
-     - generic
    * - Ubuntu 25.10
      - Questing Quokka
      - 6.17
      - generic
+   * - Ubuntu 26.04 LTS
+     - Resolute Raccoon
+     - 7.0
+     - generic, raspi
 
 .. note::
 
@@ -51,6 +51,8 @@ Ubuntu Core
      - 5.15; 6.8 (HWE)
    * - Ubuntu Core 24
      - 6.8; 6.14 (HWE)
+   * - Ubuntu Core 26
+     - 7.0
 
 .. note::
 

--- a/docs/reference/releases.rst
+++ b/docs/reference/releases.rst
@@ -50,13 +50,13 @@ Ubuntu Core
    * - Ubuntu Core 22
      - 5.15; 6.8 (HWE)
    * - Ubuntu Core 24
-     - 6.8; 6.14 (HWE)
+     - 6.8; 6.17 (HWE)
    * - Ubuntu Core 26
      - 7.0
 
 .. note::
 
-  Newer kernels (6.8, 6.14, etc) can be installed on Ubuntu Core via Hardware Enablement (HWE) kernel snaps.
+  Newer kernels (6.8, 6.17, etc) can be installed on Ubuntu Core via Hardware Enablement (HWE) kernel snaps.
   The list of publicly available kernel snaps can be found in the `pc-kernel`_ Snap Store page.
 
 To install the real-time kernel on an instance of Ubuntu Core, refer to :doc:`../how-to/uc-install-real-time-kernel`.


### PR DESCRIPTION
This includes updates for the documentation for 26.04 LTS (Resolute Raccoon). Notably, that resolute is in the main archive, and no longer requires Ubuntu Pro. Also, references to Plucky are dropped as this kernel is EOL, in favor of Questing & Resolute.